### PR TITLE
Fix: Make multiple mods be downloaded in a single SteamCmd session

### DIFF
--- a/src/main/java/cz/forgottenempire/servermanager/steamcmd/SteamCmdJob.java
+++ b/src/main/java/cz/forgottenempire/servermanager/steamcmd/SteamCmdJob.java
@@ -2,13 +2,15 @@ package cz.forgottenempire.servermanager.steamcmd;
 
 import cz.forgottenempire.servermanager.common.ServerType;
 import cz.forgottenempire.servermanager.workshop.WorkshopMod;
-import javax.validation.constraints.NotNull;
 import lombok.Data;
+
+import javax.validation.constraints.NotNull;
+import java.util.Collection;
 
 @Data
 public class SteamCmdJob {
 
-    private WorkshopMod relatedWorkshopMod;
+    private Collection<WorkshopMod> relatedWorkshopMods;
     private ServerType relatedServer;
     private ErrorStatus errorStatus;
     @NotNull
@@ -19,8 +21,8 @@ public class SteamCmdJob {
         this.steamCmdParameters = steamCmdParameters;
     }
 
-    public SteamCmdJob(WorkshopMod relatedWorkshopMod, SteamCmdParameters steamCmdParameters) {
-        this.relatedWorkshopMod = relatedWorkshopMod;
+    public SteamCmdJob(Collection<WorkshopMod> relatedWorkshopMods, SteamCmdParameters steamCmdParameters) {
+        this.relatedWorkshopMods = relatedWorkshopMods;
         this.steamCmdParameters = steamCmdParameters;
     }
 }


### PR DESCRIPTION
When downloading a large amount of mods each in a single SteamCMD process, the rate limit is exceeded and the user is blocked from using SteamCMD for a certain time period.

To avoid this, when downloading multiple mods, only a single SteamCMD session is created containing all the mod download parameters.