### PR TITLE
Use IPublishedFileService API for Mods

### DIFF
--- a/backend/src/main/java/cz/forgottenempire/servermanager/common/Constants.java
+++ b/backend/src/main/java/cz/forgottenempire/servermanager/common/Constants.java
@@ -35,5 +35,5 @@ public class Constants {
     public static final String ARMA3_PROFILE_TEMPLATE = "arma3ServerProfile.ftl";
     public static final String ARMA3_NETWORK_SETTINGS = "arma3NetworkSettings.ftl";
 
-    public final static String STEAM_API_URL = "https://api.steampowered.com/ISteamRemoteStorage/GetPublishedFileDetails/v1/";
+    public final static String STEAM_API_URL = "https://api.steampowered.com/IPublishedFileService/GetDetails/v1/";
 }

--- a/backend/src/main/java/cz/forgottenempire/servermanager/workshop/WorkshopModsFacade.java
+++ b/backend/src/main/java/cz/forgottenempire/servermanager/workshop/WorkshopModsFacade.java
@@ -17,6 +17,7 @@ import cz.forgottenempire.servermanager.workshop.metadata.ModMetadataService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Slf4j
@@ -57,6 +58,7 @@ public class WorkshopModsFacade {
         return modsService.getAllMods(filter);
     }
 
+    @Transactional
     public List<WorkshopMod> saveAndInstallMods(List<Long> ids) {
         List<WorkshopMod> workshopMods = ids.stream()
                 .map(id -> getMod(id).orElse(new WorkshopMod(id)))

--- a/backend/src/main/java/cz/forgottenempire/servermanager/workshop/WorkshopModsFacade.java
+++ b/backend/src/main/java/cz/forgottenempire/servermanager/workshop/WorkshopModsFacade.java
@@ -82,6 +82,7 @@ public class WorkshopModsFacade {
         return workshopMods;
     }
 
+    @Transactional
     public void updateAllMods() {
         List<Long> allModIds = modsService.getAllMods().stream()
                 .map(WorkshopMod::getId)

--- a/backend/src/main/java/cz/forgottenempire/servermanager/workshop/metadata/JsonPropertyProvider.java
+++ b/backend/src/main/java/cz/forgottenempire/servermanager/workshop/metadata/JsonPropertyProvider.java
@@ -19,7 +19,7 @@ class JsonPropertyProvider implements PropertyProvider {
 
     @Override
     public String findConsumerAppId() {
-        return getValueFromJson("consumer_app_id", modInfoJson);
+        return getValueFromJson("consumer_appid", modInfoJson);
     }
 
     private String getValueFromJson(String key, JsonNode modInfoJson) {

--- a/backend/src/main/java/cz/forgottenempire/servermanager/workshop/metadata/JsonPropertyProvider.java
+++ b/backend/src/main/java/cz/forgottenempire/servermanager/workshop/metadata/JsonPropertyProvider.java
@@ -1,8 +1,6 @@
 package cz.forgottenempire.servermanager.workshop.metadata;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import org.jsoup.nodes.Document;
-import org.jsoup.nodes.Element;
 
 class JsonPropertyProvider implements PropertyProvider {
 

--- a/backend/src/main/java/cz/forgottenempire/servermanager/workshop/metadata/WorkshopApiMetadataProvider.java
+++ b/backend/src/main/java/cz/forgottenempire/servermanager/workshop/metadata/WorkshopApiMetadataProvider.java
@@ -41,9 +41,9 @@ class WorkshopApiMetadataProvider extends AbstractModMetadataProvider {
 
     private JsonNode getModInfoFromSteamApi(long modId) {
         try {
-            ResponseEntity<String> response = restTemplate.postForEntity(Constants.STEAM_API_URL, prepareRequest(modId), String.class);
-            JsonNode parsedResponse = new ObjectMapper().readTree(response.getBody());
-            return parsedResponse.findValue("publishedfiledetails");
+            ResponseEntity<String> response = restTemplate.getForEntity(prepareRequest(modId), String.class);
+            JsonNode parsedResponse = new ObjectMapper().readTree(response.getBody()).findValue("response");
+            return parsedResponse.findValue("publishedfiledetails").get(0);
         } catch (RestClientException e) {
             log.error("Request to Steam Workshop API for mod ID '{}' failed", modId, e);
             return null;
@@ -53,8 +53,10 @@ class WorkshopApiMetadataProvider extends AbstractModMetadataProvider {
         }
     }
 
-    private HttpEntity<MultiValueMap<String, String>> prepareRequest(long modId) {
-        return new HttpEntity<>(prepareRequestBody(modId), prepareRequestHeaders());
+    private String prepareRequest(long modId) {
+        return Constants.STEAM_API_URL + "?key=$steamApiKey&itemcount=1&publishedfileids[0]=$modId"
+                .replace("$steamApiKey", steamApiKey)
+                .replace("$modId", String.valueOf(modId));
     }
 
     private MultiValueMap<String, String> prepareRequestBody(long modId) {

--- a/backend/src/main/java/cz/forgottenempire/servermanager/workshop/metadata/WorkshopApiMetadataProvider.java
+++ b/backend/src/main/java/cz/forgottenempire/servermanager/workshop/metadata/WorkshopApiMetadataProvider.java
@@ -1,14 +1,12 @@
 package cz.forgottenempire.servermanager.workshop.metadata;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import cz.forgottenempire.servermanager.common.Constants;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;


### PR DESCRIPTION
The current API used does not return details for unlisted/private mods even if the user whose steam api key is being used has access to them.

Also make `saveAndInstallMods` transactional so that if mods are not found (which throws) null entries are not persisted in the database, which would break the UI.