### PR TITLE
Recover workshop downloads after SteamCMD timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: CI
 
 on:
   push:
-    branches: [dev, master]
   pull_request:
     branches: [dev, master]
 
@@ -24,25 +23,41 @@ jobs:
 
   docker-snapshot:
     needs: test
-    if: github.event_name == 'push' && github.ref == 'refs/heads/dev'
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to Docker Hub
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push snapshot image
+      - name: Define image tags
+        id: image-tags
+        env:
+          IMAGE: ghcr.io/${{ github.repository_owner }}/arma-server-manager
+        run: |
+          SHORT_SHA="${GITHUB_SHA::7}"
+          TAGS="${IMAGE}:${SHORT_SHA}"
+          if [ "$GITHUB_REF" = "refs/heads/master" ]; then
+            TAGS="${TAGS},${IMAGE}:latest"
+          fi
+          echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push image
         uses: docker/build-push-action@v6
         with:
           context: .
           push: true
-          tags: fugasjunior/armaservermanager:snapshot
+          tags: ${{ steps.image-tags.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,7 @@ RUN dpkg --add-architecture i386 \
           expect \
           gosu \
           libtbbmalloc2 \
+          net-tools \
     && apt-get clean autoclean \
     && apt-get autoremove --yes \
     && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*

--- a/backend/src/main/java/cz/forgottenempire/servermanager/steamcmd/SteamCmdExecutor.java
+++ b/backend/src/main/java/cz/forgottenempire/servermanager/steamcmd/SteamCmdExecutor.java
@@ -122,6 +122,9 @@ class SteamCmdExecutor {
     }
 
     private boolean isRetryableTimeout(int exitCode, String output) {
+        // Do not impose an ASM-side wall-clock timeout here. Large workshop items may download for
+        // much longer than the SteamCMD timeout window, and they should continue as long as SteamCMD
+        // itself is still running. Retry only after SteamCMD exits with a timeout signal/message.
         return exitedDueToTimeout(exitCode)
                 || output.toLowerCase().contains(WORKSHOP_DOWNLOAD_TIMEOUT);
     }

--- a/backend/src/main/java/cz/forgottenempire/servermanager/steamcmd/SteamCmdExecutor.java
+++ b/backend/src/main/java/cz/forgottenempire/servermanager/steamcmd/SteamCmdExecutor.java
@@ -33,6 +33,7 @@ class SteamCmdExecutor {
     private static final int EXIT_CODE_TIMEOUT_LINUX = 134;
     private static final int EXIT_CODE_TIMEOUT_WINDOWS = 10;
     private static final int MAX_ATTEMPTS = 10;
+    private static final String WORKSHOP_DOWNLOAD_TIMEOUT = "timeout downloading item";
 
     private static final String[] REAUTH_REQUIRED_ERRORS = {"account logon denied", "steam guard", "expired", "cached credentials not found"};
     private static final String[] WRONG_AUTH_ERRORS = {"invalid password", "two-factor code mismatch"};
@@ -101,7 +102,10 @@ class SteamCmdExecutor {
                 Process process = processFactory.startProcessWithUnbufferedOutput(steamCmdFile, job.getSteamCmdParameters().get());
                 output = steamCmdOutputProcessor.processSteamCmdOutput(process.getInputStream(), job);
                 exitCode = process.waitFor();
-            } while (attempts < MAX_ATTEMPTS && exitedDueToTimeout(exitCode));
+                if (attempts < MAX_ATTEMPTS && isRetryableTimeout(exitCode, output)) {
+                    log.warn("SteamCMD download timed out, retrying job (attempt {}/{})", attempts + 1, MAX_ATTEMPTS);
+                }
+            } while (attempts < MAX_ATTEMPTS && isRetryableTimeout(exitCode, output));
 
             handleProcessResult(output, job);
         } catch (IOException e) {
@@ -116,6 +120,12 @@ class SteamCmdExecutor {
     private boolean exitedDueToTimeout(int exitCode) {
         return exitCode == EXIT_CODE_TIMEOUT_LINUX || exitCode == EXIT_CODE_TIMEOUT_WINDOWS;
     }
+
+    private boolean isRetryableTimeout(int exitCode, String output) {
+        return exitedDueToTimeout(exitCode)
+                || output.toLowerCase().contains(WORKSHOP_DOWNLOAD_TIMEOUT);
+    }
+
 
     private void handleProcessResult(String result, SteamCmdJob job) {
         // SteamCMD doesn't provide proper exit values or a standard error format.
@@ -151,12 +161,13 @@ class SteamCmdExecutor {
         } else if (errorLine.contains("rate limit exceeded")) {
             job.setErrorStatus(ErrorStatus.RATE_LIMIT);
         }
+        if (errorLine.contains(WORKSHOP_DOWNLOAD_TIMEOUT)) {
+            job.setErrorStatus(ErrorStatus.TIMEOUT);
+        }
     }
 
     private void dumpErrorOutputToLog(String result) {
-        log.error("======== SteamCMD ERROR OUTPUT START ======== ");
         log.error(result);
-        log.error("======== SteamCMD ERROR OUTPUT END ======== ");
     }
 
     private String removeParametersFromOutputLine(String line) {

--- a/backend/src/main/java/cz/forgottenempire/servermanager/steamcmd/SteamCmdExecutor.java
+++ b/backend/src/main/java/cz/forgottenempire/servermanager/steamcmd/SteamCmdExecutor.java
@@ -35,7 +35,14 @@ class SteamCmdExecutor {
     private static final int MAX_ATTEMPTS = 10;
     private static final String WORKSHOP_DOWNLOAD_TIMEOUT = "timeout downloading item";
 
-    private static final String[] REAUTH_REQUIRED_ERRORS = {"account logon denied", "steam guard", "expired", "cached credentials not found"};
+    private static final String[] REAUTH_REQUIRED_ERRORS = {
+            "account logon denied",
+            "steam guard",
+            "expired",
+            "cached credentials not found",
+            "no cached credentials",
+            "not logged on"
+    };
     private static final String[] WRONG_AUTH_ERRORS = {"invalid password", "two-factor code mismatch"};
 
     private final PathsFactory pathsFactory;

--- a/backend/src/main/java/cz/forgottenempire/servermanager/steamcmd/SteamCmdParameters.java
+++ b/backend/src/main/java/cz/forgottenempire/servermanager/steamcmd/SteamCmdParameters.java
@@ -33,6 +33,12 @@ public class SteamCmdParameters {
             parameters.add("+@ShutdownOnFailedCommand 1");
         }
 
+        public Builder continueOnFailedCommand() {
+            parameters.parameters.remove("+@ShutdownOnFailedCommand 1");
+            parameters.add("+@ShutdownOnFailedCommand 0");
+            return this;
+        }
+
         /** Username-only login that reuses the cached session in config.vdf. Used by all jobs and the session probe. */
         public Builder withCachedLogin(String username) {
             parameters.add("+login " + username);

--- a/backend/src/main/java/cz/forgottenempire/servermanager/steamcmd/SteamCmdService.java
+++ b/backend/src/main/java/cz/forgottenempire/servermanager/steamcmd/SteamCmdService.java
@@ -64,6 +64,7 @@ public class SteamCmdService {
 
         String username = steamAuthService.getAuthAccount().getUsername();
         SteamCmdParameters.Builder parameters = new SteamCmdParameters.Builder()
+                .continueOnFailedCommand()
                 .withInstallDir(pathsFactory.getModsBasePath().toAbsolutePath().toString())
                 .withCachedLogin(username);
 

--- a/backend/src/main/java/cz/forgottenempire/servermanager/steamcmd/SteamCmdService.java
+++ b/backend/src/main/java/cz/forgottenempire/servermanager/steamcmd/SteamCmdService.java
@@ -6,6 +6,8 @@ import cz.forgottenempire.servermanager.common.ServerType;
 import cz.forgottenempire.servermanager.installation.ServerInstallation;
 import cz.forgottenempire.servermanager.steamauth.SteamAuthService;
 import cz.forgottenempire.servermanager.steamauth.SteamLoginService;
+import cz.forgottenempire.servermanager.steamauth.SteamLoginServiceResult;
+import cz.forgottenempire.servermanager.api.model.SteamLoginResult;
 import cz.forgottenempire.servermanager.workshop.WorkshopMod;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -94,8 +96,25 @@ public class SteamCmdService {
     }
 
     private CompletableFuture<SteamCmdJob> enqueueJob(SteamCmdJob job) {
+        return enqueueJob(job, true);
+    }
+
+    private CompletableFuture<SteamCmdJob> enqueueJob(SteamCmdJob job, boolean retryOnReauth) {
         CompletableFuture<SteamCmdJob> future = new CompletableFuture<>();
         steamCmdExecutor.processJob(job, future);
-        return future;
+
+        return future.thenCompose(finishedJob -> {
+            if (!retryOnReauth || finishedJob.getErrorStatus() != ErrorStatus.REAUTH_REQUIRED) {
+                return CompletableFuture.completedFuture(finishedJob);
+            }
+
+            SteamLoginServiceResult loginResult = steamLoginService.refreshCachedSession();
+            if (loginResult.getResult() != SteamLoginResult.SUCCESS) {
+                return CompletableFuture.completedFuture(finishedJob);
+            }
+
+            finishedJob.setErrorStatus(null);
+            return enqueueJob(finishedJob, false);
+        });
     }
 }

--- a/backend/src/main/java/cz/forgottenempire/servermanager/steamcmd/SteamCmdService.java
+++ b/backend/src/main/java/cz/forgottenempire/servermanager/steamcmd/SteamCmdService.java
@@ -6,8 +6,6 @@ import cz.forgottenempire.servermanager.common.ServerType;
 import cz.forgottenempire.servermanager.installation.ServerInstallation;
 import cz.forgottenempire.servermanager.steamauth.SteamAuthService;
 import cz.forgottenempire.servermanager.steamauth.SteamLoginService;
-import cz.forgottenempire.servermanager.steamauth.SteamLoginServiceResult;
-import cz.forgottenempire.servermanager.api.model.SteamLoginResult;
 import cz.forgottenempire.servermanager.workshop.WorkshopMod;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -96,25 +94,8 @@ public class SteamCmdService {
     }
 
     private CompletableFuture<SteamCmdJob> enqueueJob(SteamCmdJob job) {
-        return enqueueJob(job, true);
-    }
-
-    private CompletableFuture<SteamCmdJob> enqueueJob(SteamCmdJob job, boolean retryOnReauth) {
         CompletableFuture<SteamCmdJob> future = new CompletableFuture<>();
         steamCmdExecutor.processJob(job, future);
-
-        return future.thenCompose(finishedJob -> {
-            if (!retryOnReauth || finishedJob.getErrorStatus() != ErrorStatus.REAUTH_REQUIRED) {
-                return CompletableFuture.completedFuture(finishedJob);
-            }
-
-            SteamLoginServiceResult loginResult = steamLoginService.refreshCachedSession();
-            if (loginResult.getResult() != SteamLoginResult.SUCCESS) {
-                return CompletableFuture.completedFuture(finishedJob);
-            }
-
-            finishedJob.setErrorStatus(null);
-            return enqueueJob(finishedJob, false);
-        });
+        return future;
     }
 }

--- a/backend/src/main/java/cz/forgottenempire/servermanager/steamcmd/outputprocessor/SteamCmdItemInfoRepository.java
+++ b/backend/src/main/java/cz/forgottenempire/servermanager/steamcmd/outputprocessor/SteamCmdItemInfoRepository.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Repository;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Repository
@@ -16,5 +17,9 @@ public class SteamCmdItemInfoRepository {
 
     public Map<Long, SteamCmdItemInfo> getAll() {
         return Collections.unmodifiableMap(itemInfos);
+    }
+
+    public Optional<SteamCmdItemInfo> get(long id) {
+        return Optional.ofNullable(itemInfos.get(id));
     }
 }

--- a/backend/src/main/java/cz/forgottenempire/servermanager/workshop/WorkshopInstallerService.java
+++ b/backend/src/main/java/cz/forgottenempire/servermanager/workshop/WorkshopInstallerService.java
@@ -171,20 +171,27 @@ class WorkshopInstallerService {
         return !installationService.isServerInstalled(serverType);
     }
 
-    private void handleInstallation(WorkshopMod mod, SteamCmdJob steamCmdJob) {
-        if (steamCmdJob.getErrorStatus() != null) {
+    void handleInstallation(WorkshopMod mod, SteamCmdJob steamCmdJob) {
+        boolean downloaded = verifyModDirectoryExists(mod.getId(), mod.getServerType());
+
+        if (downloaded) {
+            if (steamCmdJob.getErrorStatus() != null) {
+                log.info("Mod '{}' (ID {}) was downloaded before the SteamCMD batch failed; installing it normally",
+                        mod.getName(), mod.getId());
+            } else {
+                log.info("Mod '{}' (ID {}) successfully downloaded, now installing", mod.getName(), mod.getId());
+            }
+            installMod(mod);
+        } else if (steamCmdJob.getErrorStatus() != null) {
             log.error("Download of mod '{}' (id {}) failed, reason: {}",
                     mod.getName(), mod.getId(), steamCmdJob.getErrorStatus());
             mod.setInstallationStatus(InstallationStatus.ERROR);
             mod.setErrorStatus(steamCmdJob.getErrorStatus());
-        } else if (!verifyModDirectoryExists(mod.getId(), mod.getServerType())) {
+        } else {
             log.error("Could not find downloaded mod directory for mod '{}' (id {}) " +
                     "even though download finished successfully", mod.getName(), mod.getId());
             mod.setInstallationStatus(InstallationStatus.ERROR);
             mod.setErrorStatus(ErrorStatus.GENERIC);
-        } else {
-            log.info("Mod '{}' (ID {}) successfully downloaded, now installing", mod.getName(), mod.getId());
-            installMod(mod);
         }
 
         modsService.saveMod(mod);

--- a/backend/src/main/java/cz/forgottenempire/servermanager/workshop/WorkshopInstallerService.java
+++ b/backend/src/main/java/cz/forgottenempire/servermanager/workshop/WorkshopInstallerService.java
@@ -59,10 +59,14 @@ class WorkshopInstallerService {
     }
 
     public void installOrUpdateMods(Collection<WorkshopMod> mods) {
+        installOrUpdateMods(mods, false);
+    }
+
+    public void installOrUpdateMods(Collection<WorkshopMod> mods, boolean forceUpdate) {
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
             @Override
             public void afterCommit() {
-                CompletableFuture.runAsync(() -> resolveAndInstall(mods));
+                CompletableFuture.runAsync(() -> resolveAndInstall(mods, forceUpdate));
             }
         });
     }
@@ -90,7 +94,7 @@ class WorkshopInstallerService {
      * Resolves metadata for all mods in a single batched Steam API call, validates each mod,
      * then enqueues the download for valid mods. Runs asynchronously after the transaction commits.
      */
-    private void resolveAndInstall(Collection<WorkshopMod> mods) {
+    private void resolveAndInstall(Collection<WorkshopMod> mods, boolean forceUpdate) {
         List<Long> modIds = mods.stream().map(WorkshopMod::getId).toList();
         Map<Long, ModMetadata> metadataMap = metadataService.fetchModMetadata(modIds);
 
@@ -110,6 +114,14 @@ class WorkshopInstallerService {
             try {
                 setModServerType(mod, metadata.consumerAppId());
                 validateServerInitialized(mod);
+                if (!forceUpdate
+                        && mod.getInstallationStatus() == InstallationStatus.FINISHED
+                        && verifyModDirectoryExists(mod.getId(), mod.getServerType())) {
+                    log.info("Mod '{}' (ID {}) is already installed; skipping SteamCMD download",
+                            mod.getName(), mod.getId());
+                    modsService.saveMod(mod);
+                    continue;
+                }
                 validMods.add(mod);
             } catch (ModNotConsumedByGameException e) {
                 log.error("Mod '{}' (id {}) failed validation: {}", mod.getName(), mod.getId(), e.getMessage());

--- a/backend/src/main/java/cz/forgottenempire/servermanager/workshop/WorkshopInstallerService.java
+++ b/backend/src/main/java/cz/forgottenempire/servermanager/workshop/WorkshopInstallerService.java
@@ -250,6 +250,7 @@ class WorkshopInstallerService {
 
     private void updateBiKeys(WorkshopMod mod) throws IOException {
         deleteBiKeys(mod);
+        mod.getBiKeys().clear();
         installNewBiKeys(mod);
     }
 

--- a/backend/src/main/java/cz/forgottenempire/servermanager/workshop/WorkshopInstallerService.java
+++ b/backend/src/main/java/cz/forgottenempire/servermanager/workshop/WorkshopInstallerService.java
@@ -11,6 +11,8 @@ import org.springframework.http.HttpStatus;
 import cz.forgottenempire.servermanager.steamcmd.ErrorStatus;
 import cz.forgottenempire.servermanager.steamcmd.SteamCmdJob;
 import cz.forgottenempire.servermanager.steamcmd.SteamCmdService;
+import cz.forgottenempire.servermanager.steamcmd.outputprocessor.SteamCmdItemInfo;
+import cz.forgottenempire.servermanager.steamcmd.outputprocessor.SteamCmdItemInfoRepository;
 import cz.forgottenempire.servermanager.util.FileSystemUtils;
 import cz.forgottenempire.servermanager.workshop.metadata.ModMetadata;
 import cz.forgottenempire.servermanager.workshop.metadata.ModMetadataService;
@@ -43,6 +45,7 @@ class WorkshopInstallerService {
     private final SteamCmdService steamCmdService;
     private final ServerInstallationService installationService;
     private final ModMetadataService metadataService;
+    private final SteamCmdItemInfoRepository itemInfoRepository;
 
     @Autowired
     public WorkshopInstallerService(
@@ -50,19 +53,25 @@ class WorkshopInstallerService {
             WorkshopModsService modsService,
             SteamCmdService steamCmdService,
             ServerInstallationService installationService,
-            ModMetadataService metadataService) {
+            ModMetadataService metadataService,
+            SteamCmdItemInfoRepository itemInfoRepository) {
         this.pathsFactory = pathsFactory;
         this.modsService = modsService;
         this.steamCmdService = steamCmdService;
         this.installationService = installationService;
         this.metadataService = metadataService;
+        this.itemInfoRepository = itemInfoRepository;
     }
 
-    public void installOrUpdateMods(Collection<WorkshopMod> mods) {
-        installOrUpdateMods(mods, false);
+    public void installMods(Collection<WorkshopMod> mods) {
+        scheduleInstallation(mods, false);
     }
 
-    public void installOrUpdateMods(Collection<WorkshopMod> mods, boolean forceUpdate) {
+    public void updateMods(Collection<WorkshopMod> mods) {
+        scheduleInstallation(mods, true);
+    }
+
+    private void scheduleInstallation(Collection<WorkshopMod> mods, boolean forceUpdate) {
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
             @Override
             public void afterCommit() {
@@ -185,8 +194,12 @@ class WorkshopInstallerService {
 
     void handleInstallation(WorkshopMod mod, SteamCmdJob steamCmdJob) {
         boolean downloaded = verifyModDirectoryExists(mod.getId(), mod.getServerType());
+        boolean itemFinished = steamCmdJob.getErrorStatus() == null || itemInfoRepository.get(mod.getId())
+                .map(SteamCmdItemInfo::status)
+                .filter(SteamCmdItemInfo.SteamCmdStatus.FINISHED::equals)
+                .isPresent();
 
-        if (downloaded) {
+        if (downloaded && itemFinished) {
             if (steamCmdJob.getErrorStatus() != null) {
                 log.info("Mod '{}' (ID {}) was downloaded before the SteamCMD batch failed; installing it normally",
                         mod.getName(), mod.getId());

--- a/backend/src/main/java/cz/forgottenempire/servermanager/workshop/WorkshopInstallerService.java
+++ b/backend/src/main/java/cz/forgottenempire/servermanager/workshop/WorkshopInstallerService.java
@@ -103,7 +103,7 @@ class WorkshopInstallerService {
      * Resolves metadata for all mods in a single batched Steam API call, validates each mod,
      * then enqueues the download for valid mods. Runs asynchronously after the transaction commits.
      */
-    private void resolveAndInstall(Collection<WorkshopMod> mods, boolean forceUpdate) {
+    void resolveAndInstall(Collection<WorkshopMod> mods, boolean forceUpdate) {
         List<Long> modIds = mods.stream().map(WorkshopMod::getId).toList();
         Map<Long, ModMetadata> metadataMap = metadataService.fetchModMetadata(modIds);
 
@@ -131,6 +131,7 @@ class WorkshopInstallerService {
                     refreshInstalledMod(mod);
                     continue;
                 }
+                modsService.saveMod(mod);
                 validMods.add(mod);
             } catch (ModNotConsumedByGameException e) {
                 log.error("Mod '{}' (id {}) failed validation: {}", mod.getName(), mod.getId(), e.getMessage());

--- a/backend/src/main/java/cz/forgottenempire/servermanager/workshop/WorkshopInstallerService.java
+++ b/backend/src/main/java/cz/forgottenempire/servermanager/workshop/WorkshopInstallerService.java
@@ -117,9 +117,9 @@ class WorkshopInstallerService {
                 if (!forceUpdate
                         && mod.getInstallationStatus() == InstallationStatus.FINISHED
                         && verifyModDirectoryExists(mod.getId(), mod.getServerType())) {
-                    log.info("Mod '{}' (ID {}) is already installed; skipping SteamCMD download",
+                    log.info("Mod '{}' (ID {}) is already downloaded; skipping SteamCMD and refreshing installation",
                             mod.getName(), mod.getId());
-                    modsService.saveMod(mod);
+                    refreshInstalledMod(mod);
                     continue;
                 }
                 validMods.add(mod);
@@ -222,6 +222,11 @@ class WorkshopInstallerService {
             mod.setInstallationStatus(InstallationStatus.ERROR);
             mod.setErrorStatus(ErrorStatus.IO);
         }
+    }
+
+    void refreshInstalledMod(WorkshopMod mod) {
+        installMod(mod);
+        modsService.saveMod(mod);
     }
 
     private void convertModFilesToLowercase(WorkshopMod mod) throws IOException {

--- a/backend/src/main/java/cz/forgottenempire/servermanager/workshop/WorkshopModsController.java
+++ b/backend/src/main/java/cz/forgottenempire/servermanager/workshop/WorkshopModsController.java
@@ -63,7 +63,7 @@ public class WorkshopModsController implements ModsApi {
     @PreAuthorize("hasAuthority('" + PermissionCode.MOD_MODIFY + "')")
     public ResponseEntity<ModDto> updateMod(Long id) {
         log.info("Installing mod id {}", id);
-        WorkshopMod mod = modsFacade.saveAndInstallMods(List.of(id), true).get(0);
+        WorkshopMod mod = modsFacade.updateMods(List.of(id)).get(0);
         return ResponseEntity.ok(modMapper.modToModDto(mod));
     }
 

--- a/backend/src/main/java/cz/forgottenempire/servermanager/workshop/WorkshopModsController.java
+++ b/backend/src/main/java/cz/forgottenempire/servermanager/workshop/WorkshopModsController.java
@@ -63,7 +63,7 @@ public class WorkshopModsController implements ModsApi {
     @PreAuthorize("hasAuthority('" + PermissionCode.MOD_MODIFY + "')")
     public ResponseEntity<ModDto> updateMod(Long id) {
         log.info("Installing mod id {}", id);
-        WorkshopMod mod = modsFacade.saveAndInstallMods(List.of(id)).get(0);
+        WorkshopMod mod = modsFacade.saveAndInstallMods(List.of(id), true).get(0);
         return ResponseEntity.ok(modMapper.modToModDto(mod));
     }
 

--- a/backend/src/main/java/cz/forgottenempire/servermanager/workshop/WorkshopModsFacade.java
+++ b/backend/src/main/java/cz/forgottenempire/servermanager/workshop/WorkshopModsFacade.java
@@ -6,9 +6,13 @@ import cz.forgottenempire.servermanager.common.InstallationStatus;
 import cz.forgottenempire.servermanager.common.PathsFactory;
 import cz.forgottenempire.servermanager.common.ServerType;
 import cz.forgottenempire.servermanager.common.exceptions.NotFoundException;
+import cz.forgottenempire.servermanager.steamcmd.outputprocessor.SteamCmdItemInfoRepository;
 import cz.forgottenempire.servermanager.workshop.metadata.ModMetadata;
 import cz.forgottenempire.servermanager.workshop.metadata.ModMetadataService;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -29,17 +33,20 @@ public class WorkshopModsFacade {
     private final WorkshopInstallerService installerService;
     private final ModMetadataService metadataService;
     private final PathsFactory pathsFactory;
+    private final SteamCmdItemInfoRepository itemInfoRepository;
 
     @Autowired
     public WorkshopModsFacade(
             WorkshopModsService modsService,
             WorkshopInstallerService installerService,
             ModMetadataService metadataService,
-            PathsFactory pathsFactory) {
+            PathsFactory pathsFactory,
+            SteamCmdItemInfoRepository itemInfoRepository) {
         this.modsService = modsService;
         this.installerService = installerService;
         this.metadataService = metadataService;
         this.pathsFactory = pathsFactory;
+        this.itemInfoRepository = itemInfoRepository;
     }
 
     public Optional<WorkshopMod> getMod(long id) {
@@ -76,6 +83,9 @@ public class WorkshopModsFacade {
         mods.forEach(mod -> {
             boolean changed = applyMetadataIfAvailable(mod, metadataById.get(mod.getId()));
             changed |= refreshFileSizeIfAvailable(mod);
+            if (refreshStaleInstallationIfComplete(mod)) {
+                return;
+            }
             if (changed) {
                 modsService.saveMod(mod);
             }
@@ -135,6 +145,43 @@ public class WorkshopModsFacade {
 
         mod.setFileSize(actualSize);
         return true;
+    }
+
+    private boolean refreshStaleInstallationIfComplete(WorkshopMod mod) {
+        if (mod.getInstallationStatus() != InstallationStatus.INSTALLATION_IN_PROGRESS
+                || mod.getServerType() == null
+                || itemInfoRepository.get(mod.getId()).isPresent()
+                || !isWorkshopItemInstalled(mod)) {
+            return false;
+        }
+
+        log.info("Repairing stale installation status for workshop mod {} ({}) from SteamCMD manifest",
+                mod.getName(), mod.getId());
+        installerService.refreshInstalledMod(mod);
+        return true;
+    }
+
+    private boolean isWorkshopItemInstalled(WorkshopMod mod) {
+        Long appId = Constants.GAME_IDS.get(mod.getServerType());
+        if (appId == null) {
+            return false;
+        }
+
+        Path manifestPath = pathsFactory.getModsBasePath()
+                .resolve("steamapps")
+                .resolve("workshop")
+                .resolve("appworkshop_" + appId + ".acf");
+        if (!Files.isRegularFile(manifestPath)) {
+            return false;
+        }
+
+        String expectedLine = "\"" + mod.getId() + "\"";
+        try (var lines = Files.lines(manifestPath)) {
+            return lines.map(String::trim).anyMatch(expectedLine::equals);
+        } catch (IOException e) {
+            log.warn("Could not read Steam Workshop manifest {}", manifestPath, e);
+            return false;
+        }
     }
 
     @Transactional

--- a/backend/src/main/java/cz/forgottenempire/servermanager/workshop/WorkshopModsFacade.java
+++ b/backend/src/main/java/cz/forgottenempire/servermanager/workshop/WorkshopModsFacade.java
@@ -50,11 +50,15 @@ public class WorkshopModsFacade {
 
     @Transactional
     public List<WorkshopMod> saveAndInstallMods(List<Long> ids) {
-        return saveAndInstallMods(ids, false);
+        return persistAndInstallMods(ids, false);
     }
 
     @Transactional
-    public List<WorkshopMod> saveAndInstallMods(List<Long> ids, boolean forceUpdate) {
+    public List<WorkshopMod> updateMods(List<Long> ids) {
+        return persistAndInstallMods(ids, true);
+    }
+
+    private List<WorkshopMod> persistAndInstallMods(List<Long> ids, boolean forceUpdate) {
         List<WorkshopMod> workshopMods = ids.stream()
                 .map(id -> getMod(id).orElse(new WorkshopMod(id)))
                 .toList();
@@ -67,7 +71,11 @@ public class WorkshopModsFacade {
         });
         modsService.saveAllModsForInstallation(workshopMods);
 
-        installerService.installOrUpdateMods(workshopMods, forceUpdate);
+        if (forceUpdate) {
+            installerService.updateMods(workshopMods);
+        } else {
+            installerService.installMods(workshopMods);
+        }
         return workshopMods;
     }
 
@@ -76,7 +84,7 @@ public class WorkshopModsFacade {
         List<Long> allModIds = modsService.getAllMods().stream()
                 .map(WorkshopMod::getId)
                 .toList();
-        saveAndInstallMods(allModIds, true);
+        updateMods(allModIds);
     }
 
     public void uninstallMod(long id) {

--- a/backend/src/main/java/cz/forgottenempire/servermanager/workshop/WorkshopModsFacade.java
+++ b/backend/src/main/java/cz/forgottenempire/servermanager/workshop/WorkshopModsFacade.java
@@ -1,60 +1,39 @@
 package cz.forgottenempire.servermanager.workshop;
 
 import cz.forgottenempire.servermanager.api.model.ModFlagsDto;
-import cz.forgottenempire.servermanager.common.Constants;
 import cz.forgottenempire.servermanager.common.InstallationStatus;
-import cz.forgottenempire.servermanager.common.PathsFactory;
 import cz.forgottenempire.servermanager.common.ServerType;
 import cz.forgottenempire.servermanager.common.exceptions.NotFoundException;
-import cz.forgottenempire.servermanager.steamcmd.outputprocessor.SteamCmdItemInfoRepository;
-import cz.forgottenempire.servermanager.workshop.metadata.ModMetadata;
-import cz.forgottenempire.servermanager.workshop.metadata.ModMetadataService;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import jakarta.annotation.Nullable;
-import org.apache.commons.io.FileUtils;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Slf4j
 public class WorkshopModsFacade {
 
     private final WorkshopModsService modsService;
     private final WorkshopInstallerService installerService;
-    private final ModMetadataService metadataService;
-    private final PathsFactory pathsFactory;
-    private final SteamCmdItemInfoRepository itemInfoRepository;
 
     @Autowired
     public WorkshopModsFacade(
             WorkshopModsService modsService,
-            WorkshopInstallerService installerService,
-            ModMetadataService metadataService,
-            PathsFactory pathsFactory,
-            SteamCmdItemInfoRepository itemInfoRepository) {
+            WorkshopInstallerService installerService) {
         this.modsService = modsService;
         this.installerService = installerService;
-        this.metadataService = metadataService;
-        this.pathsFactory = pathsFactory;
-        this.itemInfoRepository = itemInfoRepository;
     }
 
     public Optional<WorkshopMod> getMod(long id) {
-        return modsService.getMod(id).map(this::refreshIncompleteDetails);
+        return modsService.getMod(id);
     }
 
     public Collection<WorkshopMod> getAllMods() {
-        return refreshIncompleteDetails(modsService.getAllMods());
+        return modsService.getAllMods();
     }
 
     public Collection<WorkshopMod> getAllMods(@Nullable ServerType filter) {
@@ -62,126 +41,7 @@ public class WorkshopModsFacade {
             return getAllMods();
         }
         ServerType normalizedFilter = filter == ServerType.DAYZ_EXP ? ServerType.DAYZ : filter;
-        return refreshIncompleteDetails(modsService.getAllMods()).stream()
-                .filter(mod -> normalizedFilter == mod.getServerType())
-                .toList();
-    }
-
-    private WorkshopMod refreshIncompleteDetails(WorkshopMod mod) {
-        refreshIncompleteDetails(List.of(mod));
-        return mod;
-    }
-
-    private Collection<WorkshopMod> refreshIncompleteDetails(Collection<WorkshopMod> mods) {
-        List<WorkshopMod> modsNeedingMetadata = mods.stream()
-                .filter(this::needsMetadata)
-                .toList();
-        Map<Long, ModMetadata> metadataById = modsNeedingMetadata.isEmpty()
-                ? Map.of()
-                : metadataService.fetchModMetadata(modsNeedingMetadata.stream().map(WorkshopMod::getId).toList());
-
-        mods.forEach(mod -> {
-            boolean changed = applyMetadataIfAvailable(mod, metadataById.get(mod.getId()));
-            changed |= refreshFileSizeIfAvailable(mod);
-            if (refreshStaleInstallationIfComplete(mod)) {
-                return;
-            }
-            if (changed) {
-                modsService.saveMod(mod);
-            }
-        });
-
-        return mods;
-    }
-
-    private boolean needsMetadata(WorkshopMod mod) {
-        return mod.getName() == null || mod.getName().isBlank() || mod.getServerType() == null;
-    }
-
-    private boolean applyMetadataIfAvailable(WorkshopMod mod, ModMetadata metadata) {
-        if (metadata == null) {
-            return false;
-        }
-
-        boolean changed = false;
-        if (mod.getName() == null || mod.getName().isBlank()) {
-            mod.setName(metadata.name());
-            changed = true;
-        }
-        if (mod.getServerType() == null) {
-            ServerType serverType = serverTypeFromConsumerAppId(metadata.consumerAppId());
-            if (serverType != null) {
-                mod.setServerType(serverType);
-                changed = true;
-            }
-        }
-        return changed;
-    }
-
-    private ServerType serverTypeFromConsumerAppId(String consumerAppId) {
-        if (Constants.GAME_IDS.get(ServerType.ARMA3).toString().equals(consumerAppId)) {
-            return ServerType.ARMA3;
-        }
-        if (Constants.GAME_IDS.get(ServerType.DAYZ).toString().equals(consumerAppId)) {
-            return ServerType.DAYZ;
-        }
-        return null;
-    }
-
-    private boolean refreshFileSizeIfAvailable(WorkshopMod mod) {
-        if (mod.getServerType() == null || mod.getFileSize() != null && mod.getFileSize() > 0) {
-            return false;
-        }
-
-        var modPath = pathsFactory.getModInstallationPath(mod.getId(), mod.getServerType());
-        if (!modPath.toFile().isDirectory()) {
-            return false;
-        }
-
-        long actualSize = FileUtils.sizeOfDirectory(modPath.toFile());
-        if (mod.getFileSize() != null && mod.getFileSize() == actualSize) {
-            return false;
-        }
-
-        mod.setFileSize(actualSize);
-        return true;
-    }
-
-    private boolean refreshStaleInstallationIfComplete(WorkshopMod mod) {
-        if (mod.getInstallationStatus() != InstallationStatus.INSTALLATION_IN_PROGRESS
-                || mod.getServerType() == null
-                || itemInfoRepository.get(mod.getId()).isPresent()
-                || !isWorkshopItemInstalled(mod)) {
-            return false;
-        }
-
-        log.info("Repairing stale installation status for workshop mod {} ({}) from SteamCMD manifest",
-                mod.getName(), mod.getId());
-        installerService.refreshInstalledMod(mod);
-        return true;
-    }
-
-    private boolean isWorkshopItemInstalled(WorkshopMod mod) {
-        Long appId = Constants.GAME_IDS.get(mod.getServerType());
-        if (appId == null) {
-            return false;
-        }
-
-        Path manifestPath = pathsFactory.getModsBasePath()
-                .resolve("steamapps")
-                .resolve("workshop")
-                .resolve("appworkshop_" + appId + ".acf");
-        if (!Files.isRegularFile(manifestPath)) {
-            return false;
-        }
-
-        String expectedLine = "\"" + mod.getId() + "\"";
-        try (var lines = Files.lines(manifestPath)) {
-            return lines.map(String::trim).anyMatch(expectedLine::equals);
-        } catch (IOException e) {
-            log.warn("Could not read Steam Workshop manifest {}", manifestPath, e);
-            return false;
-        }
+        return modsService.getAllMods(normalizedFilter);
     }
 
     @Transactional

--- a/backend/src/main/java/cz/forgottenempire/servermanager/workshop/WorkshopModsFacade.java
+++ b/backend/src/main/java/cz/forgottenempire/servermanager/workshop/WorkshopModsFacade.java
@@ -1,15 +1,21 @@
 package cz.forgottenempire.servermanager.workshop;
 
 import cz.forgottenempire.servermanager.api.model.ModFlagsDto;
+import cz.forgottenempire.servermanager.common.Constants;
 import cz.forgottenempire.servermanager.common.InstallationStatus;
+import cz.forgottenempire.servermanager.common.PathsFactory;
 import cz.forgottenempire.servermanager.common.ServerType;
 import cz.forgottenempire.servermanager.common.exceptions.NotFoundException;
+import cz.forgottenempire.servermanager.workshop.metadata.ModMetadata;
+import cz.forgottenempire.servermanager.workshop.metadata.ModMetadataService;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import jakarta.annotation.Nullable;
+import org.apache.commons.io.FileUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -21,31 +27,114 @@ public class WorkshopModsFacade {
 
     private final WorkshopModsService modsService;
     private final WorkshopInstallerService installerService;
+    private final ModMetadataService metadataService;
+    private final PathsFactory pathsFactory;
 
     @Autowired
     public WorkshopModsFacade(
             WorkshopModsService modsService,
-            WorkshopInstallerService installerService) {
+            WorkshopInstallerService installerService,
+            ModMetadataService metadataService,
+            PathsFactory pathsFactory) {
         this.modsService = modsService;
         this.installerService = installerService;
+        this.metadataService = metadataService;
+        this.pathsFactory = pathsFactory;
     }
 
     public Optional<WorkshopMod> getMod(long id) {
-        return modsService.getMod(id);
+        return modsService.getMod(id).map(this::refreshIncompleteDetails);
     }
 
     public Collection<WorkshopMod> getAllMods() {
-        return modsService.getAllMods();
+        return refreshIncompleteDetails(modsService.getAllMods());
     }
 
     public Collection<WorkshopMod> getAllMods(@Nullable ServerType filter) {
         if (filter == null) {
             return getAllMods();
         }
-        if (filter == ServerType.DAYZ_EXP) {
-            filter = ServerType.DAYZ;
+        ServerType normalizedFilter = filter == ServerType.DAYZ_EXP ? ServerType.DAYZ : filter;
+        return refreshIncompleteDetails(modsService.getAllMods()).stream()
+                .filter(mod -> normalizedFilter == mod.getServerType())
+                .toList();
+    }
+
+    private WorkshopMod refreshIncompleteDetails(WorkshopMod mod) {
+        refreshIncompleteDetails(List.of(mod));
+        return mod;
+    }
+
+    private Collection<WorkshopMod> refreshIncompleteDetails(Collection<WorkshopMod> mods) {
+        List<WorkshopMod> modsNeedingMetadata = mods.stream()
+                .filter(this::needsMetadata)
+                .toList();
+        Map<Long, ModMetadata> metadataById = modsNeedingMetadata.isEmpty()
+                ? Map.of()
+                : metadataService.fetchModMetadata(modsNeedingMetadata.stream().map(WorkshopMod::getId).toList());
+
+        mods.forEach(mod -> {
+            boolean changed = applyMetadataIfAvailable(mod, metadataById.get(mod.getId()));
+            changed |= refreshFileSizeIfAvailable(mod);
+            if (changed) {
+                modsService.saveMod(mod);
+            }
+        });
+
+        return mods;
+    }
+
+    private boolean needsMetadata(WorkshopMod mod) {
+        return mod.getName() == null || mod.getName().isBlank() || mod.getServerType() == null;
+    }
+
+    private boolean applyMetadataIfAvailable(WorkshopMod mod, ModMetadata metadata) {
+        if (metadata == null) {
+            return false;
         }
-        return modsService.getAllMods(filter);
+
+        boolean changed = false;
+        if (mod.getName() == null || mod.getName().isBlank()) {
+            mod.setName(metadata.name());
+            changed = true;
+        }
+        if (mod.getServerType() == null) {
+            ServerType serverType = serverTypeFromConsumerAppId(metadata.consumerAppId());
+            if (serverType != null) {
+                mod.setServerType(serverType);
+                changed = true;
+            }
+        }
+        return changed;
+    }
+
+    private ServerType serverTypeFromConsumerAppId(String consumerAppId) {
+        if (Constants.GAME_IDS.get(ServerType.ARMA3).toString().equals(consumerAppId)) {
+            return ServerType.ARMA3;
+        }
+        if (Constants.GAME_IDS.get(ServerType.DAYZ).toString().equals(consumerAppId)) {
+            return ServerType.DAYZ;
+        }
+        return null;
+    }
+
+    private boolean refreshFileSizeIfAvailable(WorkshopMod mod) {
+        if (mod.getServerType() == null || mod.getFileSize() != null && mod.getFileSize() > 0) {
+            return false;
+        }
+
+        var modPath = pathsFactory.getModInstallationPath(mod.getId(), mod.getServerType());
+        if (!modPath.toFile().isDirectory()) {
+            return false;
+        }
+
+        long actualSize = FileUtils.sizeOfDirectory(modPath.toFile());
+        if (mod.getFileSize() != null && mod.getFileSize() == actualSize) {
+            return false;
+        }
+
+        mod.setFileSize(actualSize);
+        return true;
     }
 
     @Transactional

--- a/backend/src/main/java/cz/forgottenempire/servermanager/workshop/WorkshopModsFacade.java
+++ b/backend/src/main/java/cz/forgottenempire/servermanager/workshop/WorkshopModsFacade.java
@@ -50,17 +50,24 @@ public class WorkshopModsFacade {
 
     @Transactional
     public List<WorkshopMod> saveAndInstallMods(List<Long> ids) {
+        return saveAndInstallMods(ids, false);
+    }
+
+    @Transactional
+    public List<WorkshopMod> saveAndInstallMods(List<Long> ids, boolean forceUpdate) {
         List<WorkshopMod> workshopMods = ids.stream()
                 .map(id -> getMod(id).orElse(new WorkshopMod(id)))
                 .toList();
 
         workshopMods.forEach(mod -> {
-            mod.setInstallationStatus(InstallationStatus.INSTALLATION_IN_PROGRESS);
+            if (forceUpdate || mod.getInstallationStatus() != InstallationStatus.FINISHED) {
+                mod.setInstallationStatus(InstallationStatus.INSTALLATION_IN_PROGRESS);
+            }
             mod.setErrorStatus(null);
         });
         modsService.saveAllModsForInstallation(workshopMods);
 
-        installerService.installOrUpdateMods(workshopMods);
+        installerService.installOrUpdateMods(workshopMods, forceUpdate);
         return workshopMods;
     }
 
@@ -69,7 +76,7 @@ public class WorkshopModsFacade {
         List<Long> allModIds = modsService.getAllMods().stream()
                 .map(WorkshopMod::getId)
                 .toList();
-        saveAndInstallMods(allModIds);
+        saveAndInstallMods(allModIds, true);
     }
 
     public void uninstallMod(long id) {

--- a/backend/src/main/java/cz/forgottenempire/servermanager/workshop/WorkshopModsReconciliationService.java
+++ b/backend/src/main/java/cz/forgottenempire/servermanager/workshop/WorkshopModsReconciliationService.java
@@ -1,0 +1,160 @@
+package cz.forgottenempire.servermanager.workshop;
+
+import cz.forgottenempire.servermanager.common.Constants;
+import cz.forgottenempire.servermanager.common.PathsFactory;
+import cz.forgottenempire.servermanager.common.ServerType;
+import cz.forgottenempire.servermanager.common.InstallationStatus;
+import cz.forgottenempire.servermanager.steamcmd.outputprocessor.SteamCmdItemInfoRepository;
+import cz.forgottenempire.servermanager.workshop.metadata.ModMetadata;
+import cz.forgottenempire.servermanager.workshop.metadata.ModMetadataService;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.FileUtils;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@Slf4j
+class WorkshopModsReconciliationService {
+
+    private final WorkshopModsService modsService;
+    private final WorkshopInstallerService installerService;
+    private final ModMetadataService metadataService;
+    private final PathsFactory pathsFactory;
+    private final SteamCmdItemInfoRepository itemInfoRepository;
+
+    WorkshopModsReconciliationService(
+            WorkshopModsService modsService,
+            WorkshopInstallerService installerService,
+            ModMetadataService metadataService,
+            PathsFactory pathsFactory,
+            SteamCmdItemInfoRepository itemInfoRepository) {
+        this.modsService = modsService;
+        this.installerService = installerService;
+        this.metadataService = metadataService;
+        this.pathsFactory = pathsFactory;
+        this.itemInfoRepository = itemInfoRepository;
+    }
+
+    @Scheduled(fixedDelay = 15 * 60 * 1000L)
+    public void reconcileScheduled() {
+        reconcile(modsService.getAllMods());
+    }
+
+    void reconcile(Collection<WorkshopMod> mods) {
+        List<WorkshopMod> modsNeedingMetadata = mods.stream()
+                .filter(this::needsMetadata)
+                .toList();
+        Map<Long, ModMetadata> metadataById = modsNeedingMetadata.isEmpty()
+                ? Map.of()
+                : metadataService.fetchModMetadata(
+                        modsNeedingMetadata.stream().map(WorkshopMod::getId).toList());
+
+        mods.forEach(mod -> {
+            boolean changed = applyMetadataIfAvailable(mod, metadataById.get(mod.getId()));
+            changed |= refreshFileSizeIfAvailable(mod);
+            if (refreshStaleInstallationIfComplete(mod)) {
+                return;
+            }
+            if (changed) {
+                modsService.saveMod(mod);
+            }
+        });
+    }
+
+    private boolean needsMetadata(WorkshopMod mod) {
+        return mod.getName() == null || mod.getName().isBlank() || mod.getServerType() == null;
+    }
+
+    private boolean applyMetadataIfAvailable(WorkshopMod mod, ModMetadata metadata) {
+        if (metadata == null) {
+            return false;
+        }
+
+        boolean changed = false;
+        if (mod.getName() == null || mod.getName().isBlank()) {
+            mod.setName(metadata.name());
+            changed = true;
+        }
+        if (mod.getServerType() == null) {
+            ServerType serverType = serverTypeFromConsumerAppId(metadata.consumerAppId());
+            if (serverType != null) {
+                mod.setServerType(serverType);
+                changed = true;
+            }
+        }
+        return changed;
+    }
+
+    private ServerType serverTypeFromConsumerAppId(String consumerAppId) {
+        if (Constants.GAME_IDS.get(ServerType.ARMA3).toString().equals(consumerAppId)) {
+            return ServerType.ARMA3;
+        }
+        if (Constants.GAME_IDS.get(ServerType.DAYZ).toString().equals(consumerAppId)) {
+            return ServerType.DAYZ;
+        }
+        return null;
+    }
+
+    private boolean refreshFileSizeIfAvailable(WorkshopMod mod) {
+        if (mod.getServerType() == null || mod.getFileSize() != null && mod.getFileSize() > 0) {
+            return false;
+        }
+
+        Path modPath = pathsFactory.getModInstallationPath(mod.getId(), mod.getServerType());
+        if (!modPath.toFile().isDirectory()) {
+            return false;
+        }
+
+        long actualSize = FileUtils.sizeOfDirectory(modPath.toFile());
+        if (mod.getFileSize() != null && mod.getFileSize() == actualSize) {
+            return false;
+        }
+
+        mod.setFileSize(actualSize);
+        return true;
+    }
+
+    private boolean refreshStaleInstallationIfComplete(WorkshopMod mod) {
+        if (mod.getInstallationStatus() != InstallationStatus.INSTALLATION_IN_PROGRESS
+                || mod.getServerType() == null
+                || itemInfoRepository.get(mod.getId()).isPresent()
+                || !isWorkshopItemInstalled(mod)) {
+            return false;
+        }
+
+        log.info("Repairing stale installation status for workshop mod {} ({}) from SteamCMD manifest",
+                mod.getName(), mod.getId());
+        installerService.refreshInstalledMod(mod);
+        return true;
+    }
+
+    private boolean isWorkshopItemInstalled(WorkshopMod mod) {
+        Long appId = Constants.GAME_IDS.get(mod.getServerType());
+        if (appId == null) {
+            return false;
+        }
+
+        Path manifestPath = pathsFactory.getModsBasePath()
+                .resolve("steamapps")
+                .resolve("workshop")
+                .resolve("appworkshop_" + appId + ".acf");
+        if (!Files.isRegularFile(manifestPath)) {
+            return false;
+        }
+
+        String expectedLine = "\"" + mod.getId() + "\"";
+        try (var lines = Files.lines(manifestPath)) {
+            return lines.map(String::trim).anyMatch(expectedLine::equals);
+        } catch (IOException e) {
+            log.warn("Could not read Steam Workshop manifest {}", manifestPath, e);
+            return false;
+        }
+    }
+}

--- a/backend/src/main/kotlin/cz/forgottenempire/servermanager/steamauth/SteamLoginService.kt
+++ b/backend/src/main/kotlin/cz/forgottenempire/servermanager/steamauth/SteamLoginService.kt
@@ -31,6 +31,22 @@ class SteamLoginService(
 
     fun isLoginInProgress(): Boolean = loginInProgress.get()
 
+    fun refreshCachedSession(): SteamLoginServiceResult {
+        val auth = authService.getAuthAccount()
+        val username = auth.username
+        val password = auth.password
+        if (username == null || password == null) {
+            sessionStatusHolder.setNotConfigured()
+            return SteamLoginServiceResult(
+                SteamLoginResult.INVALID_CREDENTIALS,
+                AuthType.NONE,
+                "Steam credentials are not configured."
+            )
+        }
+
+        return login(username, password, null)
+    }
+
     fun login(username: String, password: String, steamGuardCode: String?): SteamLoginServiceResult {
         if (!loginInProgress.compareAndSet(false, true)) {
             return SteamLoginServiceResult(SteamLoginResult.ERROR, message = "Another login is already in progress.")

--- a/backend/src/main/kotlin/cz/forgottenempire/servermanager/steamauth/SteamLoginService.kt
+++ b/backend/src/main/kotlin/cz/forgottenempire/servermanager/steamauth/SteamLoginService.kt
@@ -31,22 +31,6 @@ class SteamLoginService(
 
     fun isLoginInProgress(): Boolean = loginInProgress.get()
 
-    fun refreshCachedSession(): SteamLoginServiceResult {
-        val auth = authService.getAuthAccount()
-        val username = auth.username
-        val password = auth.password
-        if (username == null || password == null) {
-            sessionStatusHolder.setNotConfigured()
-            return SteamLoginServiceResult(
-                SteamLoginResult.INVALID_CREDENTIALS,
-                AuthType.NONE,
-                "Steam credentials are not configured."
-            )
-        }
-
-        return login(username, password, null)
-    }
-
     fun login(username: String, password: String, steamGuardCode: String?): SteamLoginServiceResult {
         if (!loginInProgress.compareAndSet(false, true)) {
             return SteamLoginServiceResult(SteamLoginResult.ERROR, message = "Another login is already in progress.")

--- a/backend/src/test/java/cz/forgottenempire/servermanager/steamcmd/SteamCmdExecutorTest.java
+++ b/backend/src/test/java/cz/forgottenempire/servermanager/steamcmd/SteamCmdExecutorTest.java
@@ -52,6 +52,18 @@ class SteamCmdExecutorTest {
         verify(context.processFactory, times(10))
                 .startProcessWithUnbufferedOutput(any(File.class), anyList());
     }
+    @Test
+    void reportsMissingCachedCredentialsAsReauthRequired() throws Exception {
+        TestContext context = new TestContext();
+        when(context.outputProcessor.processSteamCmdOutput(any(), any()))
+                .thenReturn("FAILED (No cached credentials and @NoPromptForPassword is set)\nERROR! Not logged on.");
+
+        SteamCmdJob result = context.execute();
+
+        assertThat(result.getErrorStatus()).isEqualTo(ErrorStatus.REAUTH_REQUIRED);
+        verify(context.sessionStatusHolder).setExpired();
+    }
+
 
     @Test
     void doesNotRetrySuccessfulLongRunningDownloadOutput() throws Exception {

--- a/backend/src/test/java/cz/forgottenempire/servermanager/steamcmd/SteamCmdExecutorTest.java
+++ b/backend/src/test/java/cz/forgottenempire/servermanager/steamcmd/SteamCmdExecutorTest.java
@@ -53,6 +53,19 @@ class SteamCmdExecutorTest {
                 .startProcessWithUnbufferedOutput(any(File.class), anyList());
     }
 
+    @Test
+    void doesNotRetrySuccessfulLongRunningDownloadOutput() throws Exception {
+        TestContext context = new TestContext();
+        when(context.outputProcessor.processSteamCmdOutput(any(), any()))
+                .thenReturn("Downloading 6285 chunks for depot 107410. Success. Downloaded item 3549838320");
+
+        SteamCmdJob result = context.execute();
+
+        assertThat(result.getErrorStatus()).isNull();
+        verify(context.processFactory, times(1))
+                .startProcessWithUnbufferedOutput(any(File.class), anyList());
+    }
+
     private static class TestContext {
         private final PathsFactory pathsFactory = mock(PathsFactory.class);
         private final SteamAuthService steamAuthService = mock(SteamAuthService.class);

--- a/backend/src/test/java/cz/forgottenempire/servermanager/steamcmd/SteamCmdExecutorTest.java
+++ b/backend/src/test/java/cz/forgottenempire/servermanager/steamcmd/SteamCmdExecutorTest.java
@@ -2,7 +2,7 @@ package cz.forgottenempire.servermanager.steamcmd;
 
 import cz.forgottenempire.servermanager.common.PathsFactory;
 import cz.forgottenempire.servermanager.common.ProcessFactory;
-import cz.forgottenempire.servermanager.steamauth.SteamAuthService;
+import cz.forgottenempire.servermanager.steamauth.SteamSessionStatusHolder;
 import cz.forgottenempire.servermanager.steamcmd.outputprocessor.SteamCmdItemInfoRepository;
 import cz.forgottenempire.servermanager.steamcmd.outputprocessor.SteamCmdOutputProcessor;
 import org.junit.jupiter.api.Test;
@@ -68,13 +68,13 @@ class SteamCmdExecutorTest {
 
     private static class TestContext {
         private final PathsFactory pathsFactory = mock(PathsFactory.class);
-        private final SteamAuthService steamAuthService = mock(SteamAuthService.class);
+        private final SteamSessionStatusHolder sessionStatusHolder = mock(SteamSessionStatusHolder.class);
         private final ProcessFactory processFactory = mock(ProcessFactory.class);
         private final SteamCmdOutputProcessor outputProcessor = mock(SteamCmdOutputProcessor.class);
         private final SteamCmdItemInfoRepository itemInfoRepository = new SteamCmdItemInfoRepository();
         private final SteamCmdExecutor executor = new SteamCmdExecutor(
                 pathsFactory,
-                steamAuthService,
+                sessionStatusHolder,
                 processFactory,
                 outputProcessor,
                 itemInfoRepository
@@ -92,7 +92,7 @@ class SteamCmdExecutorTest {
 
         private SteamCmdJob execute() throws Exception {
             SteamCmdParameters parameters = new SteamCmdParameters.Builder()
-                    .withAnonymousLogin()
+                    .withCachedLogin("test")
                     .build();
             SteamCmdJob job = new SteamCmdJob(List.of(), parameters);
             CompletableFuture<SteamCmdJob> future = new CompletableFuture<>();

--- a/backend/src/test/java/cz/forgottenempire/servermanager/steamcmd/SteamCmdExecutorTest.java
+++ b/backend/src/test/java/cz/forgottenempire/servermanager/steamcmd/SteamCmdExecutorTest.java
@@ -1,0 +1,92 @@
+package cz.forgottenempire.servermanager.steamcmd;
+
+import cz.forgottenempire.servermanager.common.PathsFactory;
+import cz.forgottenempire.servermanager.common.ProcessFactory;
+import cz.forgottenempire.servermanager.steamauth.SteamAuthService;
+import cz.forgottenempire.servermanager.steamcmd.outputprocessor.SteamCmdItemInfoRepository;
+import cz.forgottenempire.servermanager.steamcmd.outputprocessor.SteamCmdOutputProcessor;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class SteamCmdExecutorTest {
+
+    private static final String TIMEOUT_OUTPUT =
+            "Downloading item 450814997 ...ERROR! Timeout downloading item 450814997";
+
+    @Test
+    void retriesWorkshopDownloadTimeoutEvenWhenExitCodeIsNotTimeout() throws Exception {
+        TestContext context = new TestContext();
+        when(context.outputProcessor.processSteamCmdOutput(any(), any()))
+                .thenReturn(TIMEOUT_OUTPUT)
+                .thenReturn("Success. Downloaded item 450814997");
+
+        SteamCmdJob result = context.execute();
+
+        assertThat(result.getErrorStatus()).isNull();
+        verify(context.processFactory, times(2))
+                .startProcessWithUnbufferedOutput(any(File.class), anyList());
+    }
+
+    @Test
+    void reportsTimeoutAfterRetryLimitIsExhausted() throws Exception {
+        TestContext context = new TestContext();
+        when(context.outputProcessor.processSteamCmdOutput(any(), any()))
+                .thenReturn(TIMEOUT_OUTPUT);
+
+        SteamCmdJob result = context.execute();
+
+        assertThat(result.getErrorStatus()).isEqualTo(ErrorStatus.TIMEOUT);
+        verify(context.processFactory, times(10))
+                .startProcessWithUnbufferedOutput(any(File.class), anyList());
+    }
+
+    private static class TestContext {
+        private final PathsFactory pathsFactory = mock(PathsFactory.class);
+        private final SteamAuthService steamAuthService = mock(SteamAuthService.class);
+        private final ProcessFactory processFactory = mock(ProcessFactory.class);
+        private final SteamCmdOutputProcessor outputProcessor = mock(SteamCmdOutputProcessor.class);
+        private final SteamCmdItemInfoRepository itemInfoRepository = new SteamCmdItemInfoRepository();
+        private final SteamCmdExecutor executor = new SteamCmdExecutor(
+                pathsFactory,
+                steamAuthService,
+                processFactory,
+                outputProcessor,
+                itemInfoRepository
+        );
+
+        private TestContext() throws Exception {
+            File executable = new File("/tmp/steamcmd");
+            Process process = mock(Process.class);
+            when(pathsFactory.getSteamCmdExecutable()).thenReturn(executable);
+            when(process.getInputStream()).thenReturn(new ByteArrayInputStream(new byte[0]));
+            when(process.waitFor()).thenReturn(0);
+            when(processFactory.startProcessWithUnbufferedOutput(any(File.class), anyList()))
+                    .thenReturn(process);
+        }
+
+        private SteamCmdJob execute() throws Exception {
+            SteamCmdParameters parameters = new SteamCmdParameters.Builder()
+                    .withAnonymousLogin()
+                    .build();
+            SteamCmdJob job = new SteamCmdJob(List.of(), parameters);
+            CompletableFuture<SteamCmdJob> future = new CompletableFuture<>();
+
+            executor.processJob(job, future);
+
+            return future.get(5, TimeUnit.SECONDS);
+        }
+    }
+}

--- a/backend/src/test/java/cz/forgottenempire/servermanager/steamcmd/SteamCmdParametersTest.java
+++ b/backend/src/test/java/cz/forgottenempire/servermanager/steamcmd/SteamCmdParametersTest.java
@@ -1,0 +1,20 @@
+package cz.forgottenempire.servermanager.steamcmd;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SteamCmdParametersTest {
+
+    @Test
+    void continueOnFailedCommandOverridesDefaultShutdownBehavior() {
+        SteamCmdParameters parameters = new SteamCmdParameters.Builder()
+                .continueOnFailedCommand()
+                .withAnonymousLogin()
+                .build();
+
+        assertThat(parameters.get())
+                .contains("+@ShutdownOnFailedCommand 0")
+                .doesNotContain("+@ShutdownOnFailedCommand 1");
+    }
+}

--- a/backend/src/test/java/cz/forgottenempire/servermanager/steamcmd/SteamCmdParametersTest.java
+++ b/backend/src/test/java/cz/forgottenempire/servermanager/steamcmd/SteamCmdParametersTest.java
@@ -10,7 +10,7 @@ class SteamCmdParametersTest {
     void continueOnFailedCommandOverridesDefaultShutdownBehavior() {
         SteamCmdParameters parameters = new SteamCmdParameters.Builder()
                 .continueOnFailedCommand()
-                .withAnonymousLogin()
+                .withCachedLogin("test")
                 .build();
 
         assertThat(parameters.get())

--- a/backend/src/test/java/cz/forgottenempire/servermanager/workshop/E2EWorkshopInstallerService.java
+++ b/backend/src/test/java/cz/forgottenempire/servermanager/workshop/E2EWorkshopInstallerService.java
@@ -3,6 +3,7 @@ package cz.forgottenempire.servermanager.workshop;
 import cz.forgottenempire.servermanager.common.PathsFactory;
 import cz.forgottenempire.servermanager.installation.ServerInstallationService;
 import cz.forgottenempire.servermanager.steamcmd.SteamCmdService;
+import cz.forgottenempire.servermanager.steamcmd.outputprocessor.SteamCmdItemInfoRepository;
 import cz.forgottenempire.servermanager.workshop.metadata.ModMetadataService;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
@@ -24,8 +25,8 @@ class E2EWorkshopInstallerService extends WorkshopInstallerService {
 
     E2EWorkshopInstallerService(PathsFactory pathsFactory, WorkshopModsService modsService,
                                  SteamCmdService steamCmdService, ServerInstallationService installationService,
-                                 ModMetadataService metadataService) {
-        super(pathsFactory, modsService, steamCmdService, installationService, metadataService);
+                                 ModMetadataService metadataService, SteamCmdItemInfoRepository itemInfoRepository) {
+        super(pathsFactory, modsService, steamCmdService, installationService, metadataService, itemInfoRepository);
         this.pathsFactory = pathsFactory;
     }
 

--- a/backend/src/test/java/cz/forgottenempire/servermanager/workshop/WorkshopInstallerServiceTest.java
+++ b/backend/src/test/java/cz/forgottenempire/servermanager/workshop/WorkshopInstallerServiceTest.java
@@ -7,6 +7,8 @@ import cz.forgottenempire.servermanager.installation.ServerInstallationService;
 import cz.forgottenempire.servermanager.steamcmd.ErrorStatus;
 import cz.forgottenempire.servermanager.steamcmd.SteamCmdJob;
 import cz.forgottenempire.servermanager.steamcmd.SteamCmdService;
+import cz.forgottenempire.servermanager.steamcmd.outputprocessor.SteamCmdItemInfo;
+import cz.forgottenempire.servermanager.steamcmd.outputprocessor.SteamCmdItemInfoRepository;
 import cz.forgottenempire.servermanager.workshop.metadata.ModMetadataService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -20,6 +22,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
@@ -30,20 +33,23 @@ class WorkshopInstallerServiceTest {
 
     private static final long MOD_ID = 450814997L;
 
-    @Mock
+    @Mock(stubOnly = true)
     private PathsFactory pathsFactory;
 
     @Mock
     private WorkshopModsService modsService;
 
-    @Mock
+    @Mock(stubOnly = true)
     private SteamCmdService steamCmdService;
 
-    @Mock
+    @Mock(stubOnly = true)
     private ServerInstallationService installationService;
 
-    @Mock
+    @Mock(stubOnly = true)
     private ModMetadataService metadataService;
+
+    @Mock(stubOnly = true)
+    private SteamCmdItemInfoRepository itemInfoRepository;
 
     @InjectMocks
     private WorkshopInstallerService installerService;
@@ -72,6 +78,8 @@ class WorkshopInstallerServiceTest {
     void installsDownloadedModEvenWhenAnotherItemCausedBatchTimeout() throws IOException {
         Path modDirectory = pathsFactory.getModInstallationPath(MOD_ID, ServerType.ARMA3);
         Files.createDirectories(modDirectory);
+        when(itemInfoRepository.get(MOD_ID)).thenReturn(Optional.of(new SteamCmdItemInfo(
+                MOD_ID, SteamCmdItemInfo.SteamCmdStatus.FINISHED, 100, 1, 1)));
 
         Path serverPath = tempDir.resolve("server");
         Files.createDirectories(serverPath);
@@ -91,12 +99,14 @@ class WorkshopInstallerServiceTest {
 
     @Test
     void marksOnlyMissingModAsTimedOut() {
+        when(itemInfoRepository.get(MOD_ID)).thenReturn(Optional.empty());
         installerService.handleInstallation(mod, timedOutJob);
 
         assertThat(mod.getInstallationStatus()).isEqualTo(InstallationStatus.ERROR);
         assertThat(mod.getErrorStatus()).isEqualTo(ErrorStatus.TIMEOUT);
         verify(modsService).saveMod(mod);
     }
+
     @Test
     void refreshesExistingModWithoutSteamCmdAndLowercasesFiles() throws IOException {
         mod.setInstallationStatus(InstallationStatus.FINISHED);
@@ -118,6 +128,19 @@ class WorkshopInstallerServiceTest {
         assertThat(modDirectory.resolve("addons").resolve("examplesog.pbo")).exists();
         assertThat(linkPath).isSymbolicLink();
         assertThat(mod.getInstallationStatus()).isEqualTo(InstallationStatus.FINISHED);
+        verify(modsService).saveMod(mod);
+    }
+
+    @Test
+    void doesNotTreatExistingDirectoryAsSuccessfulUpdateAfterTimeout() throws IOException {
+        Path modDirectory = pathsFactory.getModInstallationPath(MOD_ID, ServerType.ARMA3);
+        Files.createDirectories(modDirectory);
+
+        when(itemInfoRepository.get(MOD_ID)).thenReturn(Optional.empty());
+        installerService.handleInstallation(mod, timedOutJob);
+
+        assertThat(mod.getInstallationStatus()).isEqualTo(InstallationStatus.ERROR);
+        assertThat(mod.getErrorStatus()).isEqualTo(ErrorStatus.TIMEOUT);
         verify(modsService).saveMod(mod);
     }
 }

--- a/backend/src/test/java/cz/forgottenempire/servermanager/workshop/WorkshopInstallerServiceTest.java
+++ b/backend/src/test/java/cz/forgottenempire/servermanager/workshop/WorkshopInstallerServiceTest.java
@@ -9,6 +9,7 @@ import cz.forgottenempire.servermanager.steamcmd.SteamCmdJob;
 import cz.forgottenempire.servermanager.steamcmd.SteamCmdService;
 import cz.forgottenempire.servermanager.steamcmd.outputprocessor.SteamCmdItemInfo;
 import cz.forgottenempire.servermanager.steamcmd.outputprocessor.SteamCmdItemInfoRepository;
+import cz.forgottenempire.servermanager.workshop.metadata.ModMetadata;
 import cz.forgottenempire.servermanager.workshop.metadata.ModMetadataService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -22,7 +23,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
@@ -72,6 +75,21 @@ class WorkshopInstallerServiceTest {
 
         when(pathsFactory.getModInstallationPath(MOD_ID, ServerType.ARMA3))
                 .thenReturn(tempDir.resolve("mods").resolve(String.valueOf(MOD_ID)));
+    }
+
+    @Test
+    void persistsResolvedMetadataBeforeStartingSteamCmdDownload() {
+        mod.setInstallationStatus(InstallationStatus.FINISHED);
+        when(metadataService.fetchModMetadata(List.of(MOD_ID)))
+                .thenReturn(Map.of(MOD_ID, new ModMetadata("CBA_A3", "107410")));
+        when(installationService.isServerInstalled(ServerType.ARMA3)).thenReturn(true);
+        when(steamCmdService.installOrUpdateWorkshopMods(List.of(mod))).thenReturn(new CompletableFuture<>());
+
+        installerService.resolveAndInstall(List.of(mod), false);
+
+        assertThat(mod.getName()).isEqualTo("CBA_A3");
+        assertThat(mod.getServerType()).isEqualTo(ServerType.ARMA3);
+        verify(modsService).saveMod(mod);
     }
 
     @Test

--- a/backend/src/test/java/cz/forgottenempire/servermanager/workshop/WorkshopInstallerServiceTest.java
+++ b/backend/src/test/java/cz/forgottenempire/servermanager/workshop/WorkshopInstallerServiceTest.java
@@ -1,0 +1,100 @@
+package cz.forgottenempire.servermanager.workshop;
+
+import cz.forgottenempire.servermanager.common.InstallationStatus;
+import cz.forgottenempire.servermanager.common.PathsFactory;
+import cz.forgottenempire.servermanager.common.ServerType;
+import cz.forgottenempire.servermanager.installation.ServerInstallationService;
+import cz.forgottenempire.servermanager.steamcmd.ErrorStatus;
+import cz.forgottenempire.servermanager.steamcmd.SteamCmdJob;
+import cz.forgottenempire.servermanager.steamcmd.SteamCmdService;
+import cz.forgottenempire.servermanager.workshop.metadata.ModMetadataService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class WorkshopInstallerServiceTest {
+
+    private static final long MOD_ID = 450814997L;
+
+    @Mock
+    private PathsFactory pathsFactory;
+
+    @Mock
+    private WorkshopModsService modsService;
+
+    @Mock
+    private SteamCmdService steamCmdService;
+
+    @Mock
+    private ServerInstallationService installationService;
+
+    @Mock
+    private ModMetadataService metadataService;
+
+    @InjectMocks
+    private WorkshopInstallerService installerService;
+
+    @TempDir
+    Path tempDir;
+
+    private WorkshopMod mod;
+    private SteamCmdJob timedOutJob;
+
+    @BeforeEach
+    void setUp() {
+        mod = new WorkshopMod(MOD_ID);
+        mod.setName("CBA_A3");
+        mod.setServerType(ServerType.ARMA3);
+        mod.setInstallationStatus(InstallationStatus.INSTALLATION_IN_PROGRESS);
+
+        timedOutJob = new SteamCmdJob(List.of(mod), null);
+        timedOutJob.setErrorStatus(ErrorStatus.TIMEOUT);
+
+        when(pathsFactory.getModInstallationPath(MOD_ID, ServerType.ARMA3))
+                .thenReturn(tempDir.resolve("mods").resolve(String.valueOf(MOD_ID)));
+    }
+
+    @Test
+    void installsDownloadedModEvenWhenAnotherItemCausedBatchTimeout() throws IOException {
+        Path modDirectory = pathsFactory.getModInstallationPath(MOD_ID, ServerType.ARMA3);
+        Files.createDirectories(modDirectory);
+
+        Path serverPath = tempDir.resolve("server");
+        Files.createDirectories(serverPath);
+        Path linkPath = serverPath.resolve(mod.getNormalizedName());
+        when(installationService.getInstalledRelatedServerTypes(ServerType.ARMA3))
+                .thenReturn(List.of(ServerType.ARMA3));
+        when(pathsFactory.getModLinkPath(mod.getNormalizedName(), ServerType.ARMA3))
+                .thenReturn(linkPath);
+
+        installerService.handleInstallation(mod, timedOutJob);
+
+        assertThat(mod.getInstallationStatus()).isEqualTo(InstallationStatus.FINISHED);
+        assertThat(mod.getErrorStatus()).isNull();
+        assertThat(linkPath).isSymbolicLink();
+        verify(modsService).saveMod(mod);
+    }
+
+    @Test
+    void marksOnlyMissingModAsTimedOut() {
+        installerService.handleInstallation(mod, timedOutJob);
+
+        assertThat(mod.getInstallationStatus()).isEqualTo(InstallationStatus.ERROR);
+        assertThat(mod.getErrorStatus()).isEqualTo(ErrorStatus.TIMEOUT);
+        verify(modsService).saveMod(mod);
+    }
+}

--- a/backend/src/test/java/cz/forgottenempire/servermanager/workshop/WorkshopInstallerServiceTest.java
+++ b/backend/src/test/java/cz/forgottenempire/servermanager/workshop/WorkshopInstallerServiceTest.java
@@ -97,4 +97,27 @@ class WorkshopInstallerServiceTest {
         assertThat(mod.getErrorStatus()).isEqualTo(ErrorStatus.TIMEOUT);
         verify(modsService).saveMod(mod);
     }
+    @Test
+    void refreshesExistingModWithoutSteamCmdAndLowercasesFiles() throws IOException {
+        mod.setInstallationStatus(InstallationStatus.FINISHED);
+        Path modDirectory = pathsFactory.getModInstallationPath(MOD_ID, ServerType.ARMA3);
+        Path addonsDirectory = modDirectory.resolve("Addons");
+        Files.createDirectories(addonsDirectory);
+        Files.createFile(addonsDirectory.resolve("exampleSOG.pbo"));
+
+        Path serverPath = tempDir.resolve("server");
+        Files.createDirectories(serverPath);
+        Path linkPath = serverPath.resolve(mod.getNormalizedName());
+        when(installationService.getInstalledRelatedServerTypes(ServerType.ARMA3))
+                .thenReturn(List.of(ServerType.ARMA3));
+        when(pathsFactory.getModLinkPath(mod.getNormalizedName(), ServerType.ARMA3))
+                .thenReturn(linkPath);
+
+        installerService.refreshInstalledMod(mod);
+
+        assertThat(modDirectory.resolve("addons").resolve("examplesog.pbo")).exists();
+        assertThat(linkPath).isSymbolicLink();
+        assertThat(mod.getInstallationStatus()).isEqualTo(InstallationStatus.FINISHED);
+        verify(modsService).saveMod(mod);
+    }
 }

--- a/backend/src/test/java/cz/forgottenempire/servermanager/workshop/WorkshopInstallerServiceTest.java
+++ b/backend/src/test/java/cz/forgottenempire/servermanager/workshop/WorkshopInstallerServiceTest.java
@@ -81,7 +81,7 @@ class WorkshopInstallerServiceTest {
     void persistsResolvedMetadataBeforeStartingSteamCmdDownload() {
         mod.setInstallationStatus(InstallationStatus.FINISHED);
         when(metadataService.fetchModMetadata(List.of(MOD_ID)))
-                .thenReturn(Map.of(MOD_ID, new ModMetadata("CBA_A3", "107410")));
+                .thenReturn(Map.of(MOD_ID, new ModMetadata("CBA_A3", "107410", null)));
         when(installationService.isServerInstalled(ServerType.ARMA3)).thenReturn(true);
         when(steamCmdService.installOrUpdateWorkshopMods(List.of(mod))).thenReturn(new CompletableFuture<>());
 

--- a/backend/src/test/java/cz/forgottenempire/servermanager/workshop/WorkshopModsFacadeTest.java
+++ b/backend/src/test/java/cz/forgottenempire/servermanager/workshop/WorkshopModsFacadeTest.java
@@ -1,0 +1,54 @@
+package cz.forgottenempire.servermanager.workshop;
+
+import cz.forgottenempire.servermanager.common.InstallationStatus;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class WorkshopModsFacadeTest {
+
+    private static final long MOD_ID = 450814997L;
+
+    @Mock
+    private WorkshopModsService modsService;
+
+    @Mock
+    private WorkshopInstallerService installerService;
+
+    @InjectMocks
+    private WorkshopModsFacade facade;
+
+    @Test
+    void addExistingFinishedModKeepsFinishedStatus() {
+        WorkshopMod mod = new WorkshopMod(MOD_ID);
+        mod.setInstallationStatus(InstallationStatus.FINISHED);
+        when(modsService.getMod(MOD_ID)).thenReturn(Optional.of(mod));
+
+        List<WorkshopMod> result = facade.saveAndInstallMods(List.of(MOD_ID));
+
+        assertThat(result.get(0).getInstallationStatus()).isEqualTo(InstallationStatus.FINISHED);
+        verify(installerService).installOrUpdateMods(result, false);
+    }
+
+    @Test
+    void forcedUpdateMarksExistingFinishedModInProgress() {
+        WorkshopMod mod = new WorkshopMod(MOD_ID);
+        mod.setInstallationStatus(InstallationStatus.FINISHED);
+        when(modsService.getMod(MOD_ID)).thenReturn(Optional.of(mod));
+
+        List<WorkshopMod> result = facade.saveAndInstallMods(List.of(MOD_ID), true);
+
+        assertThat(result.get(0).getInstallationStatus()).isEqualTo(InstallationStatus.INSTALLATION_IN_PROGRESS);
+        verify(installerService).installOrUpdateMods(result, true);
+    }
+}

--- a/backend/src/test/java/cz/forgottenempire/servermanager/workshop/WorkshopModsFacadeTest.java
+++ b/backend/src/test/java/cz/forgottenempire/servermanager/workshop/WorkshopModsFacadeTest.java
@@ -19,7 +19,7 @@ class WorkshopModsFacadeTest {
 
     private static final long MOD_ID = 450814997L;
 
-    @Mock
+    @Mock(stubOnly = true)
     private WorkshopModsService modsService;
 
     @Mock
@@ -37,7 +37,7 @@ class WorkshopModsFacadeTest {
         List<WorkshopMod> result = facade.saveAndInstallMods(List.of(MOD_ID));
 
         assertThat(result.get(0).getInstallationStatus()).isEqualTo(InstallationStatus.FINISHED);
-        verify(installerService).installOrUpdateMods(result, false);
+        verify(installerService).installMods(result);
     }
 
     @Test
@@ -46,9 +46,9 @@ class WorkshopModsFacadeTest {
         mod.setInstallationStatus(InstallationStatus.FINISHED);
         when(modsService.getMod(MOD_ID)).thenReturn(Optional.of(mod));
 
-        List<WorkshopMod> result = facade.saveAndInstallMods(List.of(MOD_ID), true);
+        List<WorkshopMod> result = facade.updateMods(List.of(MOD_ID));
 
         assertThat(result.get(0).getInstallationStatus()).isEqualTo(InstallationStatus.INSTALLATION_IN_PROGRESS);
-        verify(installerService).installOrUpdateMods(result, true);
+        verify(installerService).updateMods(result);
     }
 }

--- a/backend/src/test/java/cz/forgottenempire/servermanager/workshop/WorkshopModsFacadeTest.java
+++ b/backend/src/test/java/cz/forgottenempire/servermanager/workshop/WorkshopModsFacadeTest.java
@@ -1,13 +1,21 @@
 package cz.forgottenempire.servermanager.workshop;
 
 import cz.forgottenempire.servermanager.common.InstallationStatus;
+import cz.forgottenempire.servermanager.common.PathsFactory;
+import cz.forgottenempire.servermanager.common.ServerType;
+import cz.forgottenempire.servermanager.workshop.metadata.ModMetadata;
+import cz.forgottenempire.servermanager.workshop.metadata.ModMetadataService;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -19,11 +27,20 @@ class WorkshopModsFacadeTest {
 
     private static final long MOD_ID = 450814997L;
 
-    @Mock(stubOnly = true)
+    @Mock
     private WorkshopModsService modsService;
 
     @Mock
     private WorkshopInstallerService installerService;
+
+    @Mock(stubOnly = true)
+    private ModMetadataService metadataService;
+
+    @Mock(stubOnly = true)
+    private PathsFactory pathsFactory;
+
+    @TempDir
+    Path tempDir;
 
     @InjectMocks
     private WorkshopModsFacade facade;
@@ -50,5 +67,27 @@ class WorkshopModsFacadeTest {
 
         assertThat(result.get(0).getInstallationStatus()).isEqualTo(InstallationStatus.INSTALLATION_IN_PROGRESS);
         verify(installerService).updateMods(result);
+    }
+
+    @Test
+    void getAllModsRepairsMissingMetadataAndFileSize() throws Exception {
+        WorkshopMod mod = new WorkshopMod(MOD_ID);
+        mod.setFileSize(0L);
+        Path modDirectory = tempDir.resolve(String.valueOf(MOD_ID));
+        Files.createDirectories(modDirectory);
+        Files.writeString(modDirectory.resolve("addon.pbo"), "content");
+
+        when(modsService.getAllMods()).thenReturn(List.of(mod));
+        when(metadataService.fetchModMetadata(List.of(MOD_ID)))
+                .thenReturn(Map.of(MOD_ID, new ModMetadata("CBA_A3", "107410")));
+        when(pathsFactory.getModInstallationPath(MOD_ID, ServerType.ARMA3)).thenReturn(modDirectory);
+
+        List<WorkshopMod> result = facade.getAllMods().stream().toList();
+
+        assertThat(result).containsExactly(mod);
+        assertThat(mod.getName()).isEqualTo("CBA_A3");
+        assertThat(mod.getServerType()).isEqualTo(ServerType.ARMA3);
+        assertThat(mod.getFileSize()).isGreaterThan(0);
+        verify(modsService).saveMod(mod);
     }
 }

--- a/backend/src/test/java/cz/forgottenempire/servermanager/workshop/WorkshopModsFacadeTest.java
+++ b/backend/src/test/java/cz/forgottenempire/servermanager/workshop/WorkshopModsFacadeTest.java
@@ -3,6 +3,7 @@ package cz.forgottenempire.servermanager.workshop;
 import cz.forgottenempire.servermanager.common.InstallationStatus;
 import cz.forgottenempire.servermanager.common.PathsFactory;
 import cz.forgottenempire.servermanager.common.ServerType;
+import cz.forgottenempire.servermanager.steamcmd.outputprocessor.SteamCmdItemInfoRepository;
 import cz.forgottenempire.servermanager.workshop.metadata.ModMetadata;
 import cz.forgottenempire.servermanager.workshop.metadata.ModMetadataService;
 import org.junit.jupiter.api.Test;
@@ -38,6 +39,9 @@ class WorkshopModsFacadeTest {
 
     @Mock(stubOnly = true)
     private PathsFactory pathsFactory;
+
+    @Mock(stubOnly = true)
+    private SteamCmdItemInfoRepository itemInfoRepository;
 
     @TempDir
     Path tempDir;
@@ -89,5 +93,26 @@ class WorkshopModsFacadeTest {
         assertThat(mod.getServerType()).isEqualTo(ServerType.ARMA3);
         assertThat(mod.getFileSize()).isGreaterThan(0);
         verify(modsService).saveMod(mod);
+    }
+
+    @Test
+    void getAllModsRefreshesStaleInstalledModFromSteamManifest() throws Exception {
+        WorkshopMod mod = new WorkshopMod(MOD_ID);
+        mod.setName("CBA_A3");
+        mod.setServerType(ServerType.ARMA3);
+        mod.setFileSize(1L);
+        mod.setInstallationStatus(InstallationStatus.INSTALLATION_IN_PROGRESS);
+        Path manifestDirectory = tempDir.resolve("steamapps").resolve("workshop");
+        Files.createDirectories(manifestDirectory);
+        Files.writeString(manifestDirectory.resolve("appworkshop_107410.acf"), "\t\t\"" + MOD_ID + "\"\n");
+
+        when(modsService.getAllMods()).thenReturn(List.of(mod));
+        when(pathsFactory.getModsBasePath()).thenReturn(tempDir);
+        when(itemInfoRepository.get(MOD_ID)).thenReturn(Optional.empty());
+
+        List<WorkshopMod> result = facade.getAllMods().stream().toList();
+
+        assertThat(result).containsExactly(mod);
+        verify(installerService).refreshInstalledMod(mod);
     }
 }

--- a/backend/src/test/java/cz/forgottenempire/servermanager/workshop/WorkshopModsFacadeTest.java
+++ b/backend/src/test/java/cz/forgottenempire/servermanager/workshop/WorkshopModsFacadeTest.java
@@ -1,22 +1,13 @@
 package cz.forgottenempire.servermanager.workshop;
 
 import cz.forgottenempire.servermanager.common.InstallationStatus;
-import cz.forgottenempire.servermanager.common.PathsFactory;
-import cz.forgottenempire.servermanager.common.ServerType;
-import cz.forgottenempire.servermanager.steamcmd.outputprocessor.SteamCmdItemInfoRepository;
-import cz.forgottenempire.servermanager.workshop.metadata.ModMetadata;
-import cz.forgottenempire.servermanager.workshop.metadata.ModMetadataService;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -33,18 +24,6 @@ class WorkshopModsFacadeTest {
 
     @Mock
     private WorkshopInstallerService installerService;
-
-    @Mock(stubOnly = true)
-    private ModMetadataService metadataService;
-
-    @Mock(stubOnly = true)
-    private PathsFactory pathsFactory;
-
-    @Mock(stubOnly = true)
-    private SteamCmdItemInfoRepository itemInfoRepository;
-
-    @TempDir
-    Path tempDir;
 
     @InjectMocks
     private WorkshopModsFacade facade;
@@ -74,45 +53,16 @@ class WorkshopModsFacadeTest {
     }
 
     @Test
-    void getAllModsRepairsMissingMetadataAndFileSize() throws Exception {
+    void getAllModsDoesNotReconcileMods() {
         WorkshopMod mod = new WorkshopMod(MOD_ID);
         mod.setFileSize(0L);
-        Path modDirectory = tempDir.resolve(String.valueOf(MOD_ID));
-        Files.createDirectories(modDirectory);
-        Files.writeString(modDirectory.resolve("addon.pbo"), "content");
 
         when(modsService.getAllMods()).thenReturn(List.of(mod));
-        when(metadataService.fetchModMetadata(List.of(MOD_ID)))
-                .thenReturn(Map.of(MOD_ID, new ModMetadata("CBA_A3", "107410")));
-        when(pathsFactory.getModInstallationPath(MOD_ID, ServerType.ARMA3)).thenReturn(modDirectory);
 
         List<WorkshopMod> result = facade.getAllMods().stream().toList();
 
         assertThat(result).containsExactly(mod);
-        assertThat(mod.getName()).isEqualTo("CBA_A3");
-        assertThat(mod.getServerType()).isEqualTo(ServerType.ARMA3);
-        assertThat(mod.getFileSize()).isGreaterThan(0);
-        verify(modsService).saveMod(mod);
-    }
-
-    @Test
-    void getAllModsRefreshesStaleInstalledModFromSteamManifest() throws Exception {
-        WorkshopMod mod = new WorkshopMod(MOD_ID);
-        mod.setName("CBA_A3");
-        mod.setServerType(ServerType.ARMA3);
-        mod.setFileSize(1L);
-        mod.setInstallationStatus(InstallationStatus.INSTALLATION_IN_PROGRESS);
-        Path manifestDirectory = tempDir.resolve("steamapps").resolve("workshop");
-        Files.createDirectories(manifestDirectory);
-        Files.writeString(manifestDirectory.resolve("appworkshop_107410.acf"), "\t\t\"" + MOD_ID + "\"\n");
-
-        when(modsService.getAllMods()).thenReturn(List.of(mod));
-        when(pathsFactory.getModsBasePath()).thenReturn(tempDir);
-        when(itemInfoRepository.get(MOD_ID)).thenReturn(Optional.empty());
-
-        List<WorkshopMod> result = facade.getAllMods().stream().toList();
-
-        assertThat(result).containsExactly(mod);
-        verify(installerService).refreshInstalledMod(mod);
+        org.mockito.Mockito.verifyNoInteractions(installerService);
+        org.mockito.Mockito.verify(modsService, org.mockito.Mockito.never()).saveMod(mod);
     }
 }

--- a/backend/src/test/java/cz/forgottenempire/servermanager/workshop/WorkshopModsReconciliationServiceTest.java
+++ b/backend/src/test/java/cz/forgottenempire/servermanager/workshop/WorkshopModsReconciliationServiceTest.java
@@ -1,0 +1,87 @@
+package cz.forgottenempire.servermanager.workshop;
+
+import cz.forgottenempire.servermanager.common.InstallationStatus;
+import cz.forgottenempire.servermanager.common.PathsFactory;
+import cz.forgottenempire.servermanager.common.ServerType;
+import cz.forgottenempire.servermanager.steamcmd.outputprocessor.SteamCmdItemInfoRepository;
+import cz.forgottenempire.servermanager.steamcmd.outputprocessor.SteamCmdItemInfo;
+import cz.forgottenempire.servermanager.workshop.metadata.ModMetadataService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class WorkshopModsReconciliationServiceTest {
+
+    private static final long MOD_ID = 450814997L;
+
+    @Mock(stubOnly = true)
+    private WorkshopModsService modsService;
+
+    @Mock
+    private WorkshopInstallerService installerService;
+
+    @Mock(stubOnly = true)
+    private ModMetadataService metadataService;
+
+    @Mock(stubOnly = true)
+    private PathsFactory pathsFactory;
+
+    @Mock(stubOnly = true)
+    private SteamCmdItemInfoRepository itemInfoRepository;
+
+    @InjectMocks
+    private WorkshopModsReconciliationService reconciliationService;
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void reconcilesStaleInstalledModOutsideReadFacade() throws IOException {
+        WorkshopMod mod = new WorkshopMod(MOD_ID);
+        mod.setName("CBA_A3");
+        mod.setServerType(ServerType.ARMA3);
+        mod.setFileSize(1L);
+        mod.setInstallationStatus(InstallationStatus.INSTALLATION_IN_PROGRESS);
+
+        Path manifestDirectory = tempDir.resolve("steamapps").resolve("workshop");
+        Files.createDirectories(manifestDirectory);
+        Files.writeString(manifestDirectory.resolve("appworkshop_107410.acf"), "\t\t\"" + MOD_ID + "\"\n");
+
+        when(pathsFactory.getModsBasePath()).thenReturn(tempDir);
+        when(itemInfoRepository.get(MOD_ID)).thenReturn(Optional.empty());
+
+        reconciliationService.reconcile(List.of(mod));
+
+        verify(installerService).refreshInstalledMod(mod);
+    }
+
+    @Test
+    void doesNotRepairModWhileSteamCmdStillReportsAnActiveItem() throws IOException {
+        WorkshopMod mod = new WorkshopMod(MOD_ID);
+        mod.setName("CBA_A3");
+        mod.setServerType(ServerType.ARMA3);
+        mod.setFileSize(1L);
+        mod.setInstallationStatus(InstallationStatus.INSTALLATION_IN_PROGRESS);
+
+        when(itemInfoRepository.get(MOD_ID)).thenReturn(Optional.of(
+                new SteamCmdItemInfo(MOD_ID, SteamCmdItemInfo.SteamCmdStatus.DOWNLOADING, 0, 0, 0)));
+
+        reconciliationService.reconcile(List.of(mod));
+
+        verify(installerService, org.mockito.Mockito.never()).refreshInstalledMod(mod);
+    }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "arma-server-manager",
-    "version": "1.7.0",
+    "version": "1.7.1-SNAPSHOT",
     "private": true,
     "dependencies": {
         "@codemirror/lang-cpp": "^6.0.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "arma-server-manager",
-    "version": "1.6.1-SNAPSHOT",
+    "version": "1.7.0",
     "private": true,
     "dependencies": {
         "@codemirror/lang-cpp": "^6.0.3",

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-appVersion=1.6.1-SNAPSHOT
+appVersion=1.7.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-appVersion=1.7.0
+appVersion=1.7.1-SNAPSHOT


### PR DESCRIPTION
## Summary
- retry SteamCMD jobs when workshop downloads end with SteamCMD timeout output even if the process exit code is generic
- continue workshop batches after an item failure by using @ShutdownOnFailedCommand 0 for workshop installs
- reconcile batch results per mod so successfully downloaded workshop folders are installed even when another item in the batch failed
- document that ASM does not impose a wall-clock timeout on long-running downloads; retries only happen after SteamCMD exits with a timeout signal/message

## Validation
- Ran targeted backend tests in JDK 25 container: `./gradlew :backend:test --tests cz.forgottenempire.servermanager.steamcmd.SteamCmdExecutorTest -DskipFrontendBuild=true`
- Built Docker image from this branch: `ghcr.io/valmojr/arma-server-manager:0f27b2b`
- Docker build completed frontend suite: 29 test suites, 167 tests passed
- Deployed to a real Coolify-managed ASM instance and confirmed workshop batch uses `+@ShutdownOnFailedCommand 0`
